### PR TITLE
[Members] add new taxonomies

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -27,6 +27,10 @@ enableEmoji = true
   category = "categories"
   author = "authors"
   series = "series"
+  country = "country"
+  pronouns = "pronouns"
+  chair = "chair"
+  memberships = "memberships"
 
 [sitemap]
   changefreq = 'daily'

--- a/content/country/germany/_index.md
+++ b/content/country/germany/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Germany"
+---
+
+Here is a list of all members residing in Germany.
+
+[*See all countries with members*](..)

--- a/content/members/drittelhacker/index.md
+++ b/content/members/drittelhacker/index.md
@@ -1,6 +1,9 @@
 ---
 title: "Jens Saak"
-tags: ["Chair","GAMM member","MaRDI"]
+chair: "Chair"
+tags: ["RSE","RDM"]
+memberships: ["GAMM","MaRDI"]
+country: "Germany"
 externalUrl: "https://www.mpi-magdeburg.mpg.de/person/26697/2311"
 showTaxonomies: true
 showDate: false

--- a/content/members/jpthiele/index.md
+++ b/content/members/jpthiele/index.md
@@ -1,6 +1,10 @@
 ---
 title: "Jan Philipp Thiele"
-tags: ["Chair","GAMM member","de-RSE member"]
+chair: "Chair"
+tags: ["RSE","RDM"]
+memberships: ["DE-RSE","GAMM"]
+country: "Germany"
+pronouns: "he/him"
 externalUrl: "https://github.com/jpthiele"
 showTaxonomies: true
 showDate: false

--- a/content/members/rspeck/index.md
+++ b/content/members/rspeck/index.md
@@ -1,6 +1,9 @@
 ---
 title: "Robert Speck"
-tags: ["Chair","GAMM member","de-RSE member"]
+Chair: "Chair"
+tags: ["RSE","RDM"]
+memberships: ["DE-RSE","GAMM"]
+country: "Germany"
 externalUrl: "https://www.fz-juelich.de/profile/speck_r"
 showTaxonomies: true
 showDate: false

--- a/content/memberships/de-rse/_index.md
+++ b/content/memberships/de-rse/_index.md
@@ -1,0 +1,14 @@
+---
+title: "de-RSE"
+---
+{{< figure
+    src="https://raw.githubusercontent.com/DE-RSE/logo-association/refs/heads/master/de-RSE-logo-text-colour.svg"
+    alt="de-RSE Logo"
+    class="bg-neutral"
+    href=https://de-rse.org/
+    nozoom=true
+    >}}
+
+All activity group members listed here are members of the [*Gesellschaft für Forschungssoftware de-RSE e.V.*](https://de-rse.org/)
+
+See also [*other relevant organizations of our members*](..)

--- a/content/memberships/gamm/_index.md
+++ b/content/memberships/gamm/_index.md
@@ -1,0 +1,14 @@
+---
+title: "GAMM"
+---
+{{< figure
+    src="https://www.gamm.org/wp-content/uploads/2025/01/GAMM_logo_rgb.svg"
+    alt="GAMM Logo"
+    class="bg-neutral"
+    href=https://www.gamm.org/
+    nozoom=true
+    >}}
+
+All activity group members listed here are members of the [*Gesellschaft für Angewandte Mathamtik und Mechanik e.V.*](https://www.gamm.org)
+
+See also [*other relevant organizations of our members*](..)

--- a/content/memberships/mardi/_index.md
+++ b/content/memberships/mardi/_index.md
@@ -1,0 +1,14 @@
+---
+title: "MaRDI"
+---
+{{< figure
+    src="https://www.izus.uni-stuttgart.de/fokus/img/logo-nfdi-mardi.svg?__scale=w:720,h:274,cx:0,cy:0,cw:461,ch:175"
+    alt="MaRDI Logo"
+    class="bg-neutral"
+    href=https://www.mardi4nfdi.de
+    nozoom=true
+    >}}
+
+All activity group members listed here are members of the NFDI [*Mathematical Research Data Initiative*](https://www.mardi4nfdi.de)
+
+See also [*other relevant organizations of our members*](..)

--- a/content/pronouns/_index.md
+++ b/content/pronouns/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Preferred Gender Pronouns"
+---
+
+We want to give everyone the option to list their preferred gender pronouns.
+However, we do not want to have a sorted list here on purpose.

--- a/content/pronouns/he/him/index.md
+++ b/content/pronouns/he/him/index.md
@@ -1,0 +1,7 @@
+---
+title: "he/him"
+showDate: false
+showWordCount: false
+showReadingTime: false
+---
+see [Preferred Gender Pronouns](../..)

--- a/content/pronouns/she/her/index.md
+++ b/content/pronouns/she/her/index.md
@@ -1,0 +1,7 @@
+---
+title: "she/her"
+showDate: false
+showWordCount: false
+showReadingTime: false
+---
+see [Preferred Gender Pronouns](../..)

--- a/content/pronouns/they/them/index.md
+++ b/content/pronouns/they/them/index.md
@@ -1,0 +1,7 @@
+---
+title: "they/them"
+showDate: false
+showWordCount: false
+showReadingTime: false
+---
+see [Preferred Gender Pronouns](../..)

--- a/content/tags/rdm/_index.md
+++ b/content/tags/rdm/_index.md
@@ -1,0 +1,6 @@
+---
+title: "RDM"
+---
+All our members interested in Research Data Management (RDM).
+
+See all members interested in [*Research Software Engineering*](../rse)

--- a/content/tags/rse/_index.md
+++ b/content/tags/rse/_index.md
@@ -1,0 +1,6 @@
+---
+title: "RSE"
+---
+All our members interested in Research Software Engineering (RSE).
+
+See all members interested in [*Research Data Management*](../rdm)


### PR DESCRIPTION
To get a better overview over our member structure the tags are split into categories (taxonomies).

- country, for the country of residence
- chair, so the tag stays in front
- memberships, in relevant orgs
- pronourns, for members wanting to list their preferred pronouns

RSE and RDM stay under tags.

As this auto-creates new sites I also filled them with some additional information before the respective members are listed. In case of pronouns, the listing of respective member is turned off by renaming `_index.md` to `index.md`